### PR TITLE
Fix Pivot When Is Force Filled

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -51,13 +51,13 @@ class Pivot extends Model
         // The pivot model is a "dynamic" model since we will set the tables dynamically
         // for the instance. This allows it work for any intermediate tables for the
         // many to many relationship that are defined by this developer's classes.
-        $this->forceFill($attributes);
-
-        $this->syncOriginal();
-
         $this->setTable($table);
 
         $this->setConnection($parent->getConnectionName());
+
+        $this->forceFill($attributes);
+
+        $this->syncOriginal();
 
         // We store off the parent instance so we will access the timestamp column names
         // for the model, since the pivot model timestamps aren't easily configurable

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -14,9 +14,9 @@ class DatabaseEloquentPivotTest extends PHPUnit_Framework_TestCase
     {
         $parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
         $parent->shouldReceive('getConnectionName')->once()->andReturn('connection');
-        $pivot = new Pivot($parent, ['foo' => 'bar'], 'table', true);
+        $pivot = new Pivot($parent, ['foo' => 'bar', 'created_at' => '2015-09-12'], 'table', true);
 
-        $this->assertEquals(['foo' => 'bar'], $pivot->getAttributes());
+        $this->assertEquals(['foo' => 'bar', 'created_at' => '2015-09-12'], $pivot->getAttributes());
         $this->assertEquals('connection', $pivot->getConnectionName());
         $this->assertEquals('table', $pivot->getTable());
         $this->assertTrue($pivot->exists);


### PR DESCRIPTION
This is related to Issue
[#10243](https://github.com/laravel/framework/issues/10243).

When an instance of Pivot is created and date attributes such as
created_at and updated_at are passed, it tries to convert those to a
Carbon instance using the connection’s sql grammar from the parent.

At the time the pivot is being filled, no table neither connection is
already set by the parent model, so the pivot resolves a grammar from
the default connection.

This happens when you have models that use a MySql Connection and other models that use other connection type (SqlServer, Postgres…).

The fix consist on moving `$this->setTable($table);` and
`$this->setConnection($parent->getConnectionName());` before
`$this->forceFill($attributes);` on the Pivot’s class constructor.

I tried to change the testPropertiesAreSetCorrectly test in
DatabaseEloquentPivotTest.php to reproduce the use case, as the current
test does not test that.

But got an error from PHP Unit pointing to this method in the Model
class:

```
/**
* Get the format for database stored dates.
*
* @return string
*/
protected function getDateFormat()
{
return $this->dateFormat ?:
$this->getConnection()->getQueryGrammar()->getDateFormat();
}
```

I think this is related to the mocking instance, but my testing
knowledge is not enough to fix it.

Hope this helps!, if you need more details i am able to give you if
needed.